### PR TITLE
form要素をクリックしてしまうだけでページ遷移する不具合を修正

### DIFF
--- a/frontend/src/components/page/store/LoginForm.tsx
+++ b/frontend/src/components/page/store/LoginForm.tsx
@@ -35,7 +35,7 @@ export const LoginForm: React.FC = () => {
     <div>
       <h1>店舗ログイン画面</h1>
       <h2>{errorMessage}</h2>
-      <form css={styles.FormEntire} onClick={() => handleSubmit(onSubmit)}>
+      <form css={styles.FormEntire} onSubmit={handleSubmit(onSubmit)}>
         <TextForm
           label="店舗ID（半角数字）"
           errors={errors.storeId}

--- a/frontend/src/components/page/store/LoginForm.tsx
+++ b/frontend/src/components/page/store/LoginForm.tsx
@@ -35,7 +35,7 @@ export const LoginForm: React.FC = () => {
     <div>
       <h1>店舗ログイン画面</h1>
       <h2>{errorMessage}</h2>
-      <form css={styles.FormEntire} onClick={handleSubmit(onSubmit)}>
+      <form css={styles.FormEntire} onClick={() => handleSubmit(onSubmit)}>
         <TextForm
           label="店舗ID（半角数字）"
           errors={errors.storeId}


### PR DESCRIPTION
## 解決方法を見つけた経緯
- 最初、`onClickがクリックしなくても動作してしまう`が原因かと思って、`onClick={}`の中を変更していた。
  - https://zenn.dev/eitches/articles/08526d58abd83b
- 上記を変更したことで`「form要素をクリックしてしまうだけでページ遷移する」`ではなく、Loginボタンを押してもsubmit自体ができなくなった。
- 上記は見当違いだったが、form要素の部分が原因の範囲であることがわかった。
- 他の一般的なログインフォームの実装を見て、差分を見つけた。